### PR TITLE
Update template to use Astro v1.0 RC & astro-component-tester

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,24 +19,24 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",
-    "@types/eslint": "^8.4.1",
-    "@types/mocha": "^9.1.0",
-    "@types/node": "^17.0.24",
-    "@types/prettier": "^2.6.0",
-    "@typescript-eslint/eslint-plugin": "^5.19.0",
-    "@typescript-eslint/parser": "^5.19.0",
-    "astro-component-tester": "^0.4.0",
+    "@types/eslint": "^8.4.5",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^18.6.2",
+    "@types/prettier": "^2.6.4",
+    "@typescript-eslint/eslint-plugin": "^5.31.0",
+    "@typescript-eslint/parser": "^5.31.0",
+    "astro-component-tester": "^0.6.0",
     "chai": "^4.3.6",
-    "eslint": "^8.13.0",
+    "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "mocha": "^9.2.2",
-    "prettier": "^2.6.2",
-    "prettier-plugin-astro": "^0.0.12",
-    "typescript": "^4.6.3",
-    "astro": "^1.0.0-beta.0"
+    "eslint-plugin-prettier": "^4.2.1",
+    "mocha": "^10.0.0",
+    "prettier": "^2.7.1",
+    "prettier-plugin-astro": "^0.2.0",
+    "typescript": "^4.7.4",
+    "astro": "^1.0.0-rc.3"
   },
   "peerDependencies": {
-    "astro": "^1.0.0-beta.0"
+    "astro": "^1.0.0-rc.1"
   }
 }

--- a/test/example.test.js
+++ b/test/example.test.js
@@ -18,7 +18,7 @@ describe('Example Tests', () => {
 
 		// Unless you modified /src/Component.astro, this should pass, as the component is empty apart from the frontmatter and new lines
 		it('example component should be empty', () => {
-			expect(component.html).to.equal('\n\n');
+			expect(component.html).to.equal('\n');
 		});
 	});
 });


### PR DESCRIPTION
I went ahead and bumped all dependencies (consider it housekeeping?)

The bump of Astro v1.0 rcX has to be tied with `astro-component-tester` v0.6.0 or up for compatibility with Vite 3.

I guess that an up-to-date 'component-template' could be useful in the long-term, considering the stabilization of Astro's API on v1.0 😄 